### PR TITLE
Fix PERIOD

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ const MESSAGE_PLATFORM = process.env.MESSAGE_PLATFORM || "";
 const LABEL_ENABLE = process.env.LABEL_ENABLE || 'false';
 const ONLY_OFFLINE_STATES = process.env.ONLY_OFFLINE_STATES || 'false';
 const EXCLUDE_EXITED = process.env.EXCLUDE_EXITED || 'false';
-// Default to 10 seconds if less than 10 or blank.
-if(process.env.PERIOD != "" || process.env.PERIOD < 10) {process.env.PERIOD = 10;}
+// Default to 10 seconds if less than 10, blank or undefined.
+if(process.env.PERIOD == "" || process.env.PERIOD === undefined || process.env.PERIOD < 10) {process.env.PERIOD = 10;}
 const PERIOD = process.env.PERIOD;
 const DISABLE_STARTUP_MSG = process.env.DISABLE_STARTUP_MSG || 'false';
       


### PR DESCRIPTION
Fix handling the environment setting `PERIODE`. So far it would always default to `10` seconds as the check for emptiness is wrong. Additionally, this PR will also set it to `10` if the setting is undefined.